### PR TITLE
fix bug  seriazliation attribute 

### DIFF
--- a/crates/verifier/src/tls/notarize.rs
+++ b/crates/verifier/src/tls/notarize.rs
@@ -87,9 +87,7 @@ impl Verifier<Notarize> {
                         let signature = signer.sign(attestation.as_bytes());
                         attestations.insert(attestation.to_string(), signature.into());
                     }
-                } else if path.starts_with(
-                    "https://x.com/i/api/graphql/Yka-W8dz7RaEuQNkroPkYw/UserByScreenName",
-                ) {
+                } else if path.contains("UserByScreenName") {
                     let parsed: crate::tls::x::UserByScreenName =
                         serde_json::from_str(&body).expect("failed to parse x.com response");
                     let statuses_count = parsed.data.user.result.legacy.statuses_count;
@@ -114,6 +112,14 @@ impl Verifier<Notarize> {
                         let signature = signer.sign(attestation.as_bytes());
                         attestations.insert(attestation.to_string(), signature.into());
                     }
+                } else if path.contains("dummyjson") || path.contains("swapi") {
+                    let attestation = "isHuman";
+                    let signature = signer.sign(attestation.as_bytes());
+                    attestations.insert(attestation.to_string(), signature.into());
+
+                    let attestation = "age>21";
+                    let signature = signer.sign(attestation.as_bytes());
+                    attestations.insert(attestation.to_string(), signature.into());
                 } else {
                     trace!("request path not found");
                 }

--- a/crates/verifier/src/tls/notarize.rs
+++ b/crates/verifier/src/tls/notarize.rs
@@ -87,7 +87,9 @@ impl Verifier<Notarize> {
                         let signature = signer.sign(attestation.as_bytes());
                         attestations.insert(attestation.to_string(), signature.into());
                     }
-                } else if path.contains("UserByScreenName") {
+                } else if path.starts_with(
+                    "https://x.com/i/api/graphql/Yka-W8dz7RaEuQNkroPkYw/UserByScreenName",
+                ) {
                     let parsed: crate::tls::x::UserByScreenName =
                         serde_json::from_str(&body).expect("failed to parse x.com response");
                     let statuses_count = parsed.data.user.result.legacy.statuses_count;
@@ -112,14 +114,6 @@ impl Verifier<Notarize> {
                         let signature = signer.sign(attestation.as_bytes());
                         attestations.insert(attestation.to_string(), signature.into());
                     }
-                } else if path.contains("dummyjson") || path.contains("swapi") {
-                    let attestation = "isHuman";
-                    let signature = signer.sign(attestation.as_bytes());
-                    attestations.insert(attestation.to_string(), signature.into());
-
-                    let attestation = "age>21";
-                    let signature = signer.sign(attestation.as_bytes());
-                    attestations.insert(attestation.to_string(), signature.into());
                 } else {
                     trace!("request path not found");
                 }

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -113,18 +113,40 @@ impl JsProver {
             notarized_session.application_data
         );
 
+        info!("attestations: {:?}", notarized_session.attestations);
+
         let mut attestations_vec = Vec::new();
         for (key, value) in notarized_session.attestations.iter() {
             info!("attestation: {} {:?}", key, value);
-            attestations_vec.push(format!("{}:{:?};", key, value));
+            attestations_vec.push(
+                json!({
+                    "attribute_name": key,
+                    "attribute_hex": hex::encode(key.as_bytes()),
+                    "signature": format!("{:?}", hex::encode(value.to_bytes())),
+                })
+                .to_string(),
+            );
         }
+        info!("attestations: {:?}", attestations_vec);
+        info!("attestations: {:?}", attestations_vec.join("|"));
 
-        Ok(format!(
-            "{:?}\r\n{}\r\n{}\r\n",
-            notarized_session.signature,
-            attestations_vec.join("\r\n"),
-            notarized_session.application_data
-        ))
+        use serde_json::json;
+
+        let serialized = json!({
+            "application_data": notarized_session.application_data,
+            "signature": format!("{:?}", hex::encode(notarized_session.signature.to_bytes())),
+            "attributes": attestations_vec,
+        })
+        .to_string();
+
+        Ok(serialized)
+
+        // Ok(format!(
+        //     "{:?}\r\n{}\r\n{}\r\n",
+        //     notarized_session.signature,
+        //     attestations_vec.join("\r\n"),
+        //     notarized_session.application_data
+        // ))
     }
 }
 

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -141,13 +141,6 @@ impl JsProver {
         .to_string();
 
         Ok(serialized)
-
-        // Ok(format!(
-        //     "{:?}\r\n{}\r\n{}\r\n",
-        //     notarized_session.signature,
-        //     attestations_vec.join("\r\n"),
-        //     notarized_session.application_data
-        // ))
     }
 }
 

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -122,7 +122,7 @@ impl JsProver {
                 json!({
                     "attribute_name": key,
                     "attribute_hex": hex::encode(key.as_bytes()),
-                    "signature": format!("{:?}", hex::encode(value.to_bytes())),
+                    "signature": format!("{}", hex::encode(value.to_bytes())),
                 })
                 .to_string(),
             );
@@ -134,8 +134,9 @@ impl JsProver {
 
         let serialized = json!({
             "application_data": notarized_session.application_data,
-            "signature": format!("{:?}", hex::encode(notarized_session.signature.to_bytes())),
-            "attributes": attestations_vec,
+            "signature": format!("{}", hex::encode(notarized_session.signature.to_bytes())),
+            "attributes": attestations_vec
+
         })
         .to_string();
 


### PR DESCRIPTION
we serialize properly attestation using json
instead of previous method which didn't work with several attributes and caused issues on extension & verifier app
signatures are also hex encoded properly

this PR is combined with other PRS below:
https://github.com/EternisAI/pangea-extension/pull/13  pangea-extension
https://github.com/EternisAI/pangea-js/pull/6 pangea-js 